### PR TITLE
set-env: use uname -m instead of arch

### DIFF
--- a/set-env.sh
+++ b/set-env.sh
@@ -4,7 +4,7 @@ export DOCKER_REGISTRY=${DOCKER_REGISTRY:=ghcr.io}
 export DOCKER_REPOSITORY=${DOCKER_REPOSITORY:=arm64-compat}
 export ZULU_JDK_VERSION=${ZULU_JDK_VERSION:=11.0.15-1}
 
-BUILD_ARCH=$(arch)
+BUILD_ARCH=$(uname -m)
 
 case $BUILD_ARCH in
     


### PR DESCRIPTION
`uname` is likely available by default a bit more often than `arch`, thus it should allow a wider distribution range