### PR TITLE
build-images: pass additional options

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -x
 
-source ./set-env.sh $1
+DOCKER_DIR=$1
+shift
 
-$MVN -f $1/pom.xml -Pdocker clean package
+source ./set-env.sh $DOCKER_DIR
+
+$MVN -f $DOCKER_DIR/pom.xml -Pdocker clean package $@


### PR DESCRIPTION
Allow additional parameters to be passed down to maven (ie `-Ddocker.skip-security-update-check=true` for [common-docker](https://github.com/confluentinc/common-docker/blob/d3698b4aa13eb445efec3e76d99ebf46717e95a3/pom.xml#L56))